### PR TITLE
Refactor: Centralize Compose preview configuration using custom Previ…

### DIFF
--- a/app/src/main/java/com/nei/ichigo/feature/encyclopedia/champion/ChampionScreen.kt
+++ b/app/src/main/java/com/nei/ichigo/feature/encyclopedia/champion/ChampionScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -57,13 +57,13 @@ import com.nei.ichigo.common.UiState
 import com.nei.ichigo.common.toSuccessUiState
 import com.nei.ichigo.core.designsystem.component.AsyncImage
 import com.nei.ichigo.core.designsystem.component.AsyncImageDefaults
-import com.nei.ichigo.core.designsystem.component.AsyncImagePreviewProvider
 import com.nei.ichigo.core.designsystem.component.IchigoFilterChip
 import com.nei.ichigo.core.designsystem.component.IchigoItemImage
 import com.nei.ichigo.core.designsystem.component.TransparentTopAppBar
 import com.nei.ichigo.core.designsystem.component.parallaxLayoutModifier
 import com.nei.ichigo.core.designsystem.theme.Gold
-import com.nei.ichigo.core.designsystem.theme.IchigoTheme
+import com.nei.ichigo.core.designsystem.theme.IchigoPreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreviewWrapper
 import com.nei.ichigo.core.designsystem.utils.getChampionImage
 import com.nei.ichigo.core.designsystem.utils.getChampionSkinImage
 import com.nei.ichigo.core.designsystem.utils.roleToString
@@ -352,35 +352,29 @@ fun SkinsSection(
     }
 }
 
-@PreviewLightDark
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 fun ChampionScreenPreview() {
-    IchigoTheme {
-        AsyncImagePreviewProvider(
-            width = 1215 / 2,
-            height = 717 / 2
-        ) {
-            ChampionScreen(
-                state = ChampionUiState(
-                    champion = ChampionDetail(
-                        id = "Aatrox",
-                        name = "Aatrox",
-                        skins = listOf(
-                            Skin(id = "1", num = 1, name = "Aatrox", chromas = false),
-                            Skin(id = "2", num = 2, name = "Aatrox", chromas = false),
-                            Skin(id = "3", num = 3, name = "Aatrox", chromas = false),
-                        ),
-                        image = "",
-                        tags = listOf("Assassin", "Fighter"),
-                        title = "Title",
-                        parType = "Mana",
-                        lore = "Lore",
-                        allyTips = listOf(),
-                        enemyTips = listOf(),
-                    ),
-                    version = "1.0.0",
-                ).toSuccessUiState()
-            )
-        }
-    }
+    ChampionScreen(
+        state = ChampionUiState(
+            champion = ChampionDetail(
+                id = "Aatrox",
+                name = "Aatrox",
+                skins = listOf(
+                    Skin(id = "1", num = 1, name = "Aatrox", chromas = false),
+                    Skin(id = "2", num = 2, name = "Aatrox", chromas = false),
+                    Skin(id = "3", num = 3, name = "Aatrox", chromas = false),
+                ),
+                image = "",
+                tags = listOf("Assassin", "Fighter"),
+                title = "Title",
+                parType = "Mana",
+                lore = "Lore",
+                allyTips = listOf(),
+                enemyTips = listOf(),
+            ),
+            version = "1.0.0",
+        ).toSuccessUiState()
+    )
 }

--- a/app/src/main/java/com/nei/ichigo/feature/encyclopedia/champions/ChampionsScreen.kt
+++ b/app/src/main/java/com/nei/ichigo/feature/encyclopedia/champions/ChampionsScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -40,7 +40,8 @@ import com.nei.ichigo.core.designsystem.component.IchigoItemLabel
 import com.nei.ichigo.core.designsystem.component.IchigoItemShimmerImage
 import com.nei.ichigo.core.designsystem.component.IchigoItemShimmerLabel
 import com.nei.ichigo.core.designsystem.component.ShimmerScope
-import com.nei.ichigo.core.designsystem.theme.IchigoThemePreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreviewWrapper
 import com.nei.ichigo.core.designsystem.utils.getChampionImage
 import com.nei.ichigo.core.model.Champion
 import com.nei.ichigo.feature.encyclopedia.champions.ChampionsViewModel.ChampionsUiState
@@ -197,35 +198,33 @@ fun ShimmerScope.ChampionSkeletonItem() {
     }
 }
 
-@PreviewLightDark
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 fun ChampionsScreenPreview() {
-    IchigoThemePreview {
-        ChampionsScreen(
-            state = UiState.Success(
-                ChampionsUiState(
-                    version = "1.0.0",
-                    champions = (1..100).map {
-                        Champion(
-                            id = it.toString(),
-                            name = "Champ $it",
-                            image = "",
-                            tags = emptyList()
-                        )
-                    },
-                    tags = emptyList()
-                )
+    ChampionsScreen(
+        state = UiState.Success(
+            ChampionsUiState(
+                version = "1.0.0",
+                champions = (1..100).map {
+                    Champion(
+                        id = it.toString(),
+                        name = "Champ $it",
+                        image = "",
+                        tags = emptyList()
+                    )
+                },
+                tags = emptyList()
             )
         )
-    }
+    )
 }
 
-@PreviewLightDark
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 private fun ChampionItemShimmerPreview() {
-    IchigoThemePreview {
-        ChampionsScreen(
-            state = UiState.Loading
-        )
-    }
+    ChampionsScreen(
+        state = UiState.Loading
+    )
 }

--- a/app/src/main/java/com/nei/ichigo/feature/encyclopedia/icons/IconFullscreen.kt
+++ b/app/src/main/java/com/nei/ichigo/feature/encyclopedia/icons/IconFullscreen.kt
@@ -22,12 +22,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import com.nei.ichigo.R
 import com.nei.ichigo.core.designsystem.ZoomableBox3
-import com.nei.ichigo.core.designsystem.component.AsyncImagePreviewProvider
 import com.nei.ichigo.core.designsystem.component.DEFAULT_ITEM_SIZE
 import com.nei.ichigo.core.designsystem.component.TransparentTopAppBar
+import com.nei.ichigo.core.designsystem.theme.IchigoPreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreviewWrapper
 
 context(_: AnimatedVisibilityScope)
 @Composable
@@ -92,22 +93,21 @@ fun SharedTransitionScope.IconFullscreen(
     }
 }
 
-@Preview
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 private fun IconFullscreenPreview() {
-    AsyncImagePreviewProvider {
-        SharedTransitionLayout {
-            AnimatedContent(true) {
-                if (it) {
-                    IconFullscreen(
-                        icon = IconUi(
-                            id = "1",
-                            image = "https://ddragon.leagueoflegends.com/cdn/13.19.1/img/profileicon/1.png"
-                        ),
-                        version = "13.19.1",
-                        requestClose = {}
-                    )
-                }
+    SharedTransitionLayout {
+        AnimatedContent(true) {
+            if (it) {
+                IconFullscreen(
+                    icon = IconUi(
+                        id = "1",
+                        image = "https://ddragon.leagueoflegends.com/cdn/13.19.1/img/profileicon/1.png"
+                    ),
+                    version = "13.19.1",
+                    requestClose = {}
+                )
             }
         }
     }

--- a/app/src/main/java/com/nei/ichigo/feature/encyclopedia/icons/IconsScreen.kt
+++ b/app/src/main/java/com/nei/ichigo/feature/encyclopedia/icons/IconsScreen.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -62,7 +62,8 @@ import com.nei.ichigo.core.designsystem.component.IchigoItemShimmerImage
 import com.nei.ichigo.core.designsystem.component.IchigoItemShimmerLabel
 import com.nei.ichigo.core.designsystem.component.PageInfo
 import com.nei.ichigo.core.designsystem.component.ShimmerScope
-import com.nei.ichigo.core.designsystem.theme.IchigoThemePreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreviewWrapper
 import com.nei.ichigo.core.designsystem.utils.getProfileIconImage
 import com.nei.ichigo.feature.encyclopedia.icons.IconsViewModel.IconsUiState
 
@@ -341,61 +342,60 @@ fun SharedTransitionScope.IconDetails(
     }
 }
 
-@PreviewLightDark
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 fun IconsScreenPreview() {
-    IchigoThemePreview {
-        IconsScreen(
-            state = UiState.Success(
-                content = IconsUiState(
-                    icons = (1..100).map {
-                        IconUi(
-                            id = it.toString(),
-                            image = ""
-                        )
-                    },
-                    totalIcons = 100,
-                    pageInfo = null,
-                    pageSize = 20,
-                    version = "1.0.0"
-                )
+    IconsScreen(
+        state = UiState.Success(
+            content = IconsUiState(
+                icons = (1..100).map {
+                    IconUi(
+                        id = it.toString(),
+                        image = ""
+                    )
+                },
+                totalIcons = 100,
+                pageInfo = null,
+                pageSize = 20,
+                version = "1.0.0"
             )
         )
-    }
+    )
+
 }
 
-@PreviewLightDark
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 fun IconsScreenPreview2() {
-    IchigoThemePreview {
-        IconsScreen(
-            state = UiState.Success(
-                content = IconsUiState(
-                    icons = (1..100).map {
-                        IconUi(
-                            id = it.toString(),
-                            image = ""
-                        )
-                    },
-                    totalIcons = 100,
-                    pageInfo = PageInfo(
-                        pageIndex = 0,
-                        totalPages = 10
-                    ),
-                    pageSize = 20,
-                    version = "1.0.0"
-                )
+    IconsScreen(
+        state = UiState.Success(
+            content = IconsUiState(
+                icons = (1..100).map {
+                    IconUi(
+                        id = it.toString(),
+                        image = ""
+                    )
+                },
+                totalIcons = 100,
+                pageInfo = PageInfo(
+                    pageIndex = 0,
+                    totalPages = 10
+                ),
+                pageSize = 20,
+                version = "1.0.0"
             )
         )
-    }
+    )
+
 }
 
-@PreviewLightDark
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 fun IconsScreenLoadingPreview() {
-    IchigoThemePreview {
-        IconsScreen(
-            state = UiState.Loading
-        )
-    }
+    IconsScreen(
+        state = UiState.Loading
+    )
 }

--- a/app/src/main/java/com/nei/ichigo/feature/encyclopedia/items/ItemsScreen.kt
+++ b/app/src/main/java/com/nei/ichigo/feature/encyclopedia/items/ItemsScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -51,7 +51,8 @@ import com.nei.ichigo.core.designsystem.component.IchigoItemLabel
 import com.nei.ichigo.core.designsystem.component.IchigoItemShimmerImage
 import com.nei.ichigo.core.designsystem.component.IchigoItemShimmerLabel
 import com.nei.ichigo.core.designsystem.component.ShimmerScope
-import com.nei.ichigo.core.designsystem.theme.IchigoThemePreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreviewWrapper
 import com.nei.ichigo.core.designsystem.utils.getItemImage
 import com.nei.ichigo.feature.encyclopedia.items.ItemsViewModel.ItemsUiState
 import com.nei.ichigo.feature.encyclopedia.items.ItemsViewModel.ItemsUiState.ItemUi
@@ -250,35 +251,33 @@ fun genItemPreview(
     into = into,
 )
 
-@PreviewLightDark
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 fun ItemsScreenPreview() {
-    IchigoThemePreview {
-        ItemsScreen(
-            state = UiState.Success(
-                ItemsUiState(
-                    itemsOrder = List(15) { it.toString() },
-                    itemsMap = List(15) { index ->
-                        genItemPreview(
-                            index.toString(),
-                            listOf("1", "2", "3"),
-                        )
-                    }.associateBy { it.id },
-                    maps = emptyList(),
-                    version = "1.0.0",
-                    mapsFilter = null,
-                )
+    ItemsScreen(
+        state = UiState.Success(
+            ItemsUiState(
+                itemsOrder = List(15) { it.toString() },
+                itemsMap = List(15) { index ->
+                    genItemPreview(
+                        index.toString(),
+                        listOf("1", "2", "3"),
+                    )
+                }.associateBy { it.id },
+                maps = emptyList(),
+                version = "1.0.0",
+                mapsFilter = null,
             )
         )
-    }
+    )
 }
 
-@PreviewLightDark
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 fun ItemsScreenShimmerPreview() {
-    IchigoThemePreview {
-        ItemsScreen(
-            state = UiState.Loading
-        )
-    }
+    ItemsScreen(
+        state = UiState.Loading
+    )
 }

--- a/app/src/main/java/com/nei/ichigo/feature/encyclopedia/runes/RunesScreen.kt
+++ b/app/src/main/java/com/nei/ichigo/feature/encyclopedia/runes/RunesScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -39,10 +39,11 @@ import com.nei.ichigo.common.UiState
 import com.nei.ichigo.common.layout.defaultPaddingValues
 import com.nei.ichigo.common.toSuccessUiState
 import com.nei.ichigo.core.designsystem.component.AsyncImage
-import com.nei.ichigo.core.designsystem.component.AsyncImagePreviewProvider
 import com.nei.ichigo.core.designsystem.component.DEFAULT_ITEM_PADDING
 import com.nei.ichigo.core.designsystem.component.IchigoItemImage
 import com.nei.ichigo.core.designsystem.component.IchigoItemLabel
+import com.nei.ichigo.core.designsystem.theme.IchigoPreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreviewWrapper
 import com.nei.ichigo.core.designsystem.utils.getRuneImage
 import com.nei.ichigo.core.model.Rune
 import com.nei.ichigo.core.model.RuneBranch
@@ -208,36 +209,35 @@ fun RunesTopAppBar(
     BaseTopAppBar(uiState, R.string.runes)
 }
 
-@Preview
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 private fun SpellsScreenPreview() {
-    AsyncImagePreviewProvider {
-        RunesScreen(
-            state = RunesUiState(
-                branches = List(5) {
-                    RuneBranch(
-                        id = it.toString(),
-                        name = "test $it",
-                        icon = "test $it",
-                        slots = List(4) {
-                            RuneSlot(
-                                runes = List(3) {
-                                    Rune(
-                                        id = it.toString(),
-                                        name = "test $it",
-                                        icon = "test $it",
-                                        key = it.toString(),
-                                        shortDesc = "test $it",
-                                        longDesc = "test $it",
-                                    )
-                                }
-                            )
-                        },
-                        key = it.toString()
-                    )
-                },
-                version = "1.0.0",
-            ).toSuccessUiState()
-        )
-    }
+    RunesScreen(
+        state = RunesUiState(
+            branches = List(5) {
+                RuneBranch(
+                    id = it.toString(),
+                    name = "test $it",
+                    icon = "test $it",
+                    slots = List(4) {
+                        RuneSlot(
+                            runes = List(3) {
+                                Rune(
+                                    id = it.toString(),
+                                    name = "test $it",
+                                    icon = "test $it",
+                                    key = it.toString(),
+                                    shortDesc = "test $it",
+                                    longDesc = "test $it",
+                                )
+                            }
+                        )
+                    },
+                    key = it.toString()
+                )
+            },
+            version = "1.0.0",
+        ).toSuccessUiState()
+    )
 }

--- a/app/src/main/java/com/nei/ichigo/feature/encyclopedia/skin/fullscreen/SkinFullscreenScreen.kt
+++ b/app/src/main/java/com/nei/ichigo/feature/encyclopedia/skin/fullscreen/SkinFullscreenScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nei.ichigo.R
@@ -37,10 +37,11 @@ import com.nei.ichigo.common.toSuccessUiState
 import com.nei.ichigo.core.designsystem.ZoomableBox3
 import com.nei.ichigo.core.designsystem.component.AsyncImage
 import com.nei.ichigo.core.designsystem.component.AsyncImageDefaults
-import com.nei.ichigo.core.designsystem.component.AsyncImagePreviewProvider
 import com.nei.ichigo.core.designsystem.component.BottomPager
 import com.nei.ichigo.core.designsystem.component.PageInfo
 import com.nei.ichigo.core.designsystem.component.TransparentTopAppBar
+import com.nei.ichigo.core.designsystem.theme.IchigoPreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreviewWrapper
 import com.nei.ichigo.core.designsystem.utils.getChampionSkinImage
 import com.nei.ichigo.core.model.Skin
 
@@ -182,22 +183,21 @@ fun SkinFullscreenTopAppBar(
     )
 }
 
-@Preview
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 fun SkinFullscreenPreview() {
-    AsyncImagePreviewProvider {
-        SkinFullscreenScreen(
-            state = SkinFullscreenViewModel.SkinFullscreenUiState(
-                championId = "1",
-                skin = Skin(id = "1", num = 1, name = "Aatrox", chromas = false),
-                skins = listOf(
-                    Skin(id = "1", num = 1, name = "Aatrox", chromas = false),
-                    Skin(id = "2", num = 2, name = "Aatrox", chromas = false),
-                    Skin(id = "3", num = 3, name = "Aatrox", chromas = false),
-                ),
-                selectedSkinIndex = 0,
-                version = "1.0.0"
-            ).toSuccessUiState()
-        )
-    }
+    SkinFullscreenScreen(
+        state = SkinFullscreenViewModel.SkinFullscreenUiState(
+            championId = "1",
+            skin = Skin(id = "1", num = 1, name = "Aatrox", chromas = false),
+            skins = listOf(
+                Skin(id = "1", num = 1, name = "Aatrox", chromas = false),
+                Skin(id = "2", num = 2, name = "Aatrox", chromas = false),
+                Skin(id = "3", num = 3, name = "Aatrox", chromas = false),
+            ),
+            selectedSkinIndex = 0,
+            version = "1.0.0"
+        ).toSuccessUiState()
+    )
 }

--- a/app/src/main/java/com/nei/ichigo/feature/encyclopedia/spells/SpellsScreen.kt
+++ b/app/src/main/java/com/nei/ichigo/feature/encyclopedia/spells/SpellsScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -43,7 +43,8 @@ import com.nei.ichigo.core.designsystem.component.IchigoItemLabel
 import com.nei.ichigo.core.designsystem.component.IchigoItemShimmerImage
 import com.nei.ichigo.core.designsystem.component.IchigoItemShimmerLabel
 import com.nei.ichigo.core.designsystem.component.ShimmerScope
-import com.nei.ichigo.core.designsystem.theme.IchigoThemePreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreviewWrapper
 import com.nei.ichigo.core.designsystem.utils.getSpellImage
 import com.nei.ichigo.core.model.Spell
 import com.nei.ichigo.feature.encyclopedia.spells.SpellsViewModel.SpellsUiState
@@ -206,40 +207,38 @@ fun ShimmerScope.ItemSpellShimmer() {
     }
 }
 
-@PreviewLightDark
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 private fun SpellsScreenPreview() {
-    IchigoThemePreview {
-        SpellsScreen(
-            state = UiState.Success(
-                SpellsUiState(
-                    spells = List(10) {
-                        Spell(
-                            id = "$it",
-                            name = "Spell $it",
-                            description = "",
-                            tooltip = "",
-                            image = "",
-                            summonerLevel = 0,
-                            cooldown = 0.0,
-                            modes = emptyList()
-                        )
-                    },
-                    version = "1.0",
-                    filteredModes = emptySet(),
-                    modesAvailable = emptyList(),
-                )
+    SpellsScreen(
+        state = UiState.Success(
+            SpellsUiState(
+                spells = List(10) {
+                    Spell(
+                        id = "$it",
+                        name = "Spell $it",
+                        description = "",
+                        tooltip = "",
+                        image = "",
+                        summonerLevel = 0,
+                        cooldown = 0.0,
+                        modes = emptyList()
+                    )
+                },
+                version = "1.0",
+                filteredModes = emptySet(),
+                modesAvailable = emptyList(),
             )
         )
-    }
+    )
 }
 
-@PreviewLightDark
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 private fun SpellsScreenShimmerPreview() {
-    IchigoThemePreview {
-        SpellsScreen(
-            state = UiState.Loading
-        )
-    }
+    SpellsScreen(
+        state = UiState.Loading
+    )
 }

--- a/app/src/main/java/com/nei/ichigo/feature/licenses/LicencesScreen.kt
+++ b/app/src/main/java/com/nei/ichigo/feature/licenses/LicencesScreen.kt
@@ -11,12 +11,13 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import com.mikepenz.aboutlibraries.ui.compose.android.produceLibraries
 import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 import com.nei.ichigo.R
 import com.nei.ichigo.core.designsystem.component.LoadingScreen
-import com.nei.ichigo.core.designsystem.theme.IchigoTheme
+import com.nei.ichigo.core.designsystem.theme.IchigoPreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreviewWrapper
 
 @Composable
 fun LicencesScreen(
@@ -56,10 +57,9 @@ private fun LicencesTopBar(onBackPress: () -> Unit) {
     )
 }
 
-@Preview
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 private fun LicencesScreenPreview() {
-    IchigoTheme {
-        LicencesScreen()
-    }
+    LicencesScreen()
 }

--- a/app/src/main/java/com/nei/ichigo/feature/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/nei/ichigo/feature/settings/SettingsScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -51,6 +52,8 @@ import com.nei.ichigo.common.BaseScreen
 import com.nei.ichigo.common.UiState
 import com.nei.ichigo.core.data.model.ConfigValue
 import com.nei.ichigo.core.designsystem.component.appendTitle
+import com.nei.ichigo.core.designsystem.theme.IchigoPreview
+import com.nei.ichigo.core.designsystem.theme.IchigoPreviewWrapper
 import com.nei.ichigo.core.designsystem.theme.supportsDynamicTheming
 import com.nei.ichigo.core.designsystem.utils.languageCodeToString
 import com.nei.ichigo.core.model.DarkThemeConfig
@@ -334,7 +337,8 @@ fun Item(
     }
 }
 
-@Preview
+@PreviewWrapper(IchigoPreviewWrapper::class)
+@IchigoPreview
 @Composable
 fun ChampionsSettingsDialogContentPreview() {
     SettingsScreen(

--- a/core/designsystemy/src/main/java/com/nei/ichigo/core/designsystem/theme/Preview.kt
+++ b/core/designsystemy/src/main/java/com/nei/ichigo/core/designsystem/theme/Preview.kt
@@ -1,0 +1,35 @@
+package com.nei.ichigo.core.designsystem.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
+import com.nei.ichigo.core.designsystem.component.AsyncImagePreviewProvider
+
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.FUNCTION)
+/**
+ * Custom Preview annotation that centralizes common preview configurations.
+ * Applies Light/Dark mode and adds a landscape variant.
+ */
+@PreviewLightDark
+// @Preview(name = "Landscape", device = "spec:width=640dp,height=360dp,dpi=480")
+annotation class IchigoPreview
+
+/**
+ * Provider that wraps previews with the [IchigoTheme] and [AsyncImagePreviewProvider].
+ */
+class IchigoPreviewWrapper : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable (() -> Unit)) {
+        IchigoThemePreview {
+            content()
+            /*         AsyncImagePreviewProvider(
+                     //    width = 1215 / 2,
+                     //    height = 717 / 2
+                     ) {
+                         content()
+                     }*/
+        }
+    }
+}


### PR DESCRIPTION
…ew annotations

This commit introduces a centralized approach to Compose previews by creating custom annotations and a `PreviewWrapperProvider`. This reduces boilerplate in individual screen files and ensures consistent preview configurations across the app.

**Key Changes:**

*   **Custom Preview Annotation:** Introduced `@IchigoPreview` in `Preview.kt`. This annotation currently encapsulates `@PreviewLightDark` to provide both light and dark mode previews by default.
*   **Preview Wrapper:** Created `IchigoPreviewWrapper` which implements `PreviewWrapperProvider`. This class automatically wraps preview content with `IchigoThemePreview`, removing the need to manually add theme wrappers in every preview function.
*   **Cleaned Up Previews:** Updated various screen files (e.g., `IconsScreen`, `ChampionScreen`, `RunesScreen`, `SpellsScreen`, `SettingsScreen`) to use `@PreviewWrapper(IchigoPreviewWrapper::class)` and `@IchigoPreview`.
*   **Boilerplate Removal:** Removed manual calls to `IchigoThemePreview`, `IchigoTheme`, and `AsyncImagePreviewProvider` from individual preview composables across the encyclopedia, licenses, and settings features.
*   **Dependencies:**
    *   Added a specific version reference for `androidx.compose.animation` (`1.11.0`) in the version catalog.
    *   Updated the `compose-animation` library definition to use this version reference.